### PR TITLE
REPMAP-167 Close popup correctly when clicking somewhere else on the map

### DIFF
--- a/src/RepairMap.vue
+++ b/src/RepairMap.vue
@@ -213,6 +213,7 @@
                     :class="{ 'md:h-screen': !embed }"
                     :style="embed && windowWidth > 768 ? `height: ${windowHeight}px;` : ''"
                     ref="map"
+                    @click="onMapClick($event)"
                   ></div>
                 </div>
               </div>
@@ -466,7 +467,7 @@ export default {
       //   this.locationMarkers[this.activeLocation.id].fire('click');
       //   // return this.locationMarkers[this.activeLocation.id];
       // }
-      console.log('activeLocationId changed');
+      // console.log('activeLocationId changed');
       // this.scrollIntoView();
     },
     filter(filter) {
@@ -747,6 +748,14 @@ export default {
           });
         } else {
           this.openPopup(location.id);
+        }
+      }
+    },
+    // When clicking outside of the popup (on the map) close the popup correctly
+    onMapClick(event) {
+      if (this.activeLocationId) {
+        if (event.target.classList.contains('leaflet-container')) {
+          this.closePopup();
         }
       }
     },


### PR DESCRIPTION
When clicking on the map close the popup correctly and unset the activeId